### PR TITLE
feat: add password-gated pro model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ MAX_PAGES_PER_CHUNK=30
 # 업로드된 파일이 Redis에서 유지되는 시간. 장시간 대기/처리를 고려해 24h 이상 권장.
 # 기본값: 86400 (24시간)
 FILE_TTL_SECONDS=86400
+
+# Optional: password to unlock Gemini 2.5 Pro model
+PRO_MODEL_PASSWORD=changeme

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ celery -A tasks:celery_app worker -Q analysis,default --loglevel=info
 ```
 curl -F "jokbo_files=@jokbo/sample.pdf" -F "lesson_files=@lesson/sample.pdf" \
      "http://localhost:8000/analyze/jokbo-centric?model=flash"
+# Gemini 2.5 Pro requires ?model=pro&password=<your_secret>
 
 # 진행/결과 조회
 curl http://localhost:8000/progress/<job_id>
@@ -59,6 +60,7 @@ curl -OJ http://localhost:8000/result/<job_id>/<filename>
 ```
 curl -F "jokbo_files=@jokbo/sample.pdf" -F "lesson_files=@lesson/sample.pdf" \
      "http://localhost:8000/analyze/batch?mode=jokbo-centric&model=flash"
+# Gemini 2.5 Pro: add ?model=pro&password=<your_secret>
 ```
 - mode=jokbo-centric: 각 족보 파일 × 모든 강의자료로 N개의 하위 작업 실행
 - mode=lesson-centric: 각 강의자료 × 모든 족보로 N개의 하위 작업 실행
@@ -76,7 +78,8 @@ bash scripts/smoke_batch.sh
 2) 환경변수:
 ```
 GEMINI_API_KEY=...        # 또는 GEMINI_API_KEYS=key1,key2,...
-GEMINI_MODEL=flash        # 모델은 flash로 고정
+GEMINI_MODEL=flash        # 기본 flash (pro는 비밀번호 필요)
+PRO_MODEL_PASSWORD=...    # 선택: Pro 모델을 위한 비밀번호
 REDIS_URL=redis://...
 RENDER_STORAGE_PATH=/var/data  # 쓰기 가능 경로
 ```

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -99,7 +99,8 @@ GEMINI_API_KEY=your_single_api_key_here
 GEMINI_API_KEYS=key1,key2,key3
 
 # 선택사항
-GEMINI_MODEL=flash  # flash만 지원
+GEMINI_MODEL=flash  # 기본 flash (pro는 비밀번호 필요)
+PRO_MODEL_PASSWORD=...  # Pro 모델 비밀번호
 ```
 
 #### 2. jokbodude-worker
@@ -112,6 +113,7 @@ GEMINI_API_KEY=your_single_api_key_here
 GEMINI_API_KEYS=key1,key2,key3
 
 GEMINI_MODEL=flash
+PRO_MODEL_PASSWORD=...
 ```
 
 ### Gemini API 키 발급 방법

--- a/config.py
+++ b/config.py
@@ -57,6 +57,7 @@ SAFETY_SETTINGS = [
 # Model name mapping
 MODEL_NAMES = {
     "flash": "gemini-2.5-flash",
+    "pro": "gemini-2.5-pro",
 }
 
 def create_model(model_type: str = "flash", thinking_budget: Optional[int] = None):
@@ -64,7 +65,7 @@ def create_model(model_type: str = "flash", thinking_budget: Optional[int] = Non
     Create a Gemini model with specified configuration.
     
     Args:
-        model_type: Only "flash" is supported
+        model_type: "flash" (default) or "pro"
         thinking_budget: Optional thinking budget for flash model (0-24576, -1 for auto)
     
     Returns:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -717,6 +717,10 @@
             </div>
             
             <div class="card-body">
+                <div class="form-group" style="max-width:300px;margin-bottom:1rem;">
+                    <label for="model_password">Model Password</label>
+                    <input type="password" id="model_password" placeholder="Enter password to unlock Pro" style="width:100%;padding:0.5rem 1rem;border:1px solid var(--gray-300);border-radius:8px;" />
+                </div>
                 <div class="tabs">
                     <button class="tab active" onclick="switchTab('jokbo')">
                         Exam-Centric Analysis
@@ -879,6 +883,7 @@
     <script>
         const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
         let JD_CONFIG = { multi_api_available: false, api_keys_count: 0 };
+        let modelPassword = localStorage.getItem('jd_model_password') || '';
         // Staged file buckets to allow incremental adds and removals per input
         const stagedFiles = {
             'jokbo_files': [],
@@ -959,6 +964,37 @@
             const [singleBtn, multiBtn] = group.querySelectorAll('.toggle-option');
             return multiBtn.classList.contains('active') && !multiBtn.classList.contains('disabled');
         }
+
+        async function checkModelPassword() {
+            const pwdInput = document.getElementById('model_password');
+            const pw = (pwdInput.value || '').trim();
+            try {
+                const res = await fetch(`/config?password=${encodeURIComponent(pw)}`);
+                const data = await res.json();
+                const selects = [document.getElementById('jokbo_model'), document.getElementById('lesson_model')];
+                const hasPro = data.models && data.models.includes('pro');
+                for (const sel of selects) {
+                    let opt = sel.querySelector('option[value="pro"]');
+                    if (hasPro) {
+                        if (!opt) {
+                            sel.insertAdjacentHTML('beforeend', '<option value="pro">Gemini 2.5 Pro - Quality</option>');
+                        }
+                    } else if (opt) {
+                        opt.remove();
+                        if (sel.value === 'pro') sel.value = 'flash';
+                    }
+                }
+                if (hasPro) {
+                    modelPassword = pw;
+                    localStorage.setItem('jd_model_password', pw);
+                } else {
+                    modelPassword = '';
+                    localStorage.removeItem('jd_model_password');
+                }
+            } catch (e) {
+                console.error('Password check failed', e);
+            }
+        }
         
         // Tab switching
         function switchTab(tabName) {
@@ -1024,6 +1060,11 @@
         
         // Kick off config fetch and toggle init
         initConfigAndToggles();
+        document.getElementById('model_password').addEventListener('input', checkModelPassword);
+        if (modelPassword) {
+            document.getElementById('model_password').value = modelPassword;
+            checkModelPassword();
+        }
 
         // Staged file selection helpers (allow multi-step add/remove)
         function addFilesToBucket(inputId, files, errorId) {
@@ -1177,7 +1218,8 @@
                 formData.append('multi_api', multiApi ? 'true' : 'false');
                 // Send min_relevance via both query and form
                 formData.append('min_relevance', String(minRel));
-                const response = await fetch(`/analyze/${mode}?model=${model}&multi_api=${multiApi}&min_relevance=${minRel}${userParam}`, {
+                const pwdParam = modelPassword ? `&password=${encodeURIComponent(modelPassword)}` : '';
+                const response = await fetch(`/analyze/${mode}?model=${model}&multi_api=${multiApi}&min_relevance=${minRel}${userParam}${pwdParam}`, {
                     method: 'POST',
                     body: formData
                 });

--- a/scripts/smoke_multi_api.py
+++ b/scripts/smoke_multi_api.py
@@ -46,7 +46,7 @@ def main() -> None:
     ap.add_argument('--jokbo', help='Path to jokbo PDF')
     ap.add_argument('--lessons', nargs='+', help='Paths to lesson PDFs')
     ap.add_argument('--workers', type=int, default=2, help='Max workers for multi-API')
-    ap.add_argument('--model', choices=['flash'], default=os.getenv('GEMINI_MODEL','flash'))
+    ap.add_argument('--model', choices=['flash', 'pro'], default=os.getenv('GEMINI_MODEL','flash'))
     ap.add_argument('--output', default='output/smoke_result.json')
     args = ap.parse_args()
 

--- a/tasks.py
+++ b/tasks.py
@@ -22,7 +22,7 @@ STORAGE_PATH.mkdir(parents=True, exist_ok=True)
 
 # Check if multi-API mode is available
 USE_MULTI_API = len(API_KEYS) > 1 if 'API_KEYS' in globals() else False
-MODEL_TYPE = os.getenv("GEMINI_MODEL", "flash")  # Model fixed to 'flash' by default
+MODEL_TYPE = os.getenv("GEMINI_MODEL", "flash")  # Defaults to 'flash'; 'pro' requires password
 
 # --- Celery Initialization with Configuration ---
 celery_app = Celery("tasks")


### PR DESCRIPTION
## Summary
- allow selecting Gemini 2.5 Pro via PRO_MODEL_PASSWORD
- gate pro model behind password in API and frontend
- document new model option and env variable

## Testing
- `python -m py_compile config.py web_server.py tasks.py scripts/smoke_multi_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad7572eeac832b9f8798b17b543a03