### PR TITLE
fix: avoid wrong slide insertion from filename collisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ persistent_storage/
 
 # 테스트 파일 (개인 데이터 참조)
 test_*.py
+!tests/test_*.py
+

--- a/docs/ALGORITHMS.md
+++ b/docs/ALGORITHMS.md
@@ -165,7 +165,7 @@ The multi‑API layer distributes work across multiple keys and transparently fa
 
 - Produces a jokbo‑first sequence: questions (extracted from jokbo PDFs) followed by related lesson slides and an explanation page.
 - If there are no matches, generates a minimal “분석 결과 없음” PDF so downstream storage doesn’t fail.
-- `_resolve_lesson_path` normalizes lesson filenames to tolerate prefixes like `강의자료_` and minor naming differences; this is critical because upstream analyzers normalize filenames.
+ - `_resolve_lesson_path` and `_resolve_jokbo_path` normalize filenames to tolerate common prefixes and minor naming differences, and they refuse ambiguous matches so colliding filenames do not insert the wrong slide.
 
 
 ## Job Pipeline and Progress

--- a/pdf_creator.py
+++ b/pdf_creator.py
@@ -117,7 +117,7 @@ class PDFCreator:
             for p in files:
                 name_norm = self._normalize_korean(p.name)
                 name_key = re.sub(r"[\s_\-]+", "", name_norm).lower()
-                mapping_full[name_key] = p
+                mapping_full.setdefault(name_key, []).append(p)
                 # Stem without extension
                 stem_norm = self._normalize_korean(p.stem)
                 stem_key = re.sub(r"[\s_\-]+", "", stem_norm).lower()
@@ -128,7 +128,7 @@ class PDFCreator:
                 except Exception:
                     stripped_full_norm = name_norm
                 full_stripped_key = re.sub(r"[\s_\-]+", "", stripped_full_norm).lower()
-                mapping_full_stripped[full_stripped_key] = p
+                mapping_full_stripped.setdefault(full_stripped_key, []).append(p)
                 try:
                     stripped_stem_norm = re.sub(r"^(족보|jokbo|exam|시험|기출|중간|기말)[\s_\-]+", "", stem_norm, flags=re.IGNORECASE)
                 except Exception:
@@ -163,17 +163,17 @@ class PDFCreator:
         needle_stem_stripped = _keyify(Path(_strip_prefix(jokbo_filename) or '').stem)
 
         # 2) Exact sanitized filename match
-        candidate = mapping_full.get(needle_full)
-        if candidate and candidate.exists():
-            self.log_debug(f"Matched jokbo file by exact full name: '{jokbo_filename}' -> '{candidate.name}'")
-            return candidate
+        candidates = mapping_full.get(needle_full) or []
+        if len(candidates) == 1 and candidates[0].exists():
+            self.log_debug(f"Matched jokbo file by exact full name: '{jokbo_filename}' -> '{candidates[0].name}'")
+            return candidates[0]
 
         # 3) Prefix-stripped exact filename match
         if needle_full_stripped and needle_full_stripped != needle_full:
-            candidate = mapping_full_stripped.get(needle_full_stripped)
-            if candidate and candidate.exists():
-                self.log_debug(f"Matched by prefix-stripped jokbo name: '{jokbo_filename}' -> '{candidate.name}'")
-                return candidate
+            candidates = mapping_full_stripped.get(needle_full_stripped) or []
+            if len(candidates) == 1 and candidates[0].exists():
+                self.log_debug(f"Matched by prefix-stripped jokbo name: '{jokbo_filename}' -> '{candidates[0].name}'")
+                return candidates[0]
 
         # 4) Exact sanitized stem match (unique)
         if needle_stem:
@@ -197,8 +197,8 @@ class PDFCreator:
 
         Matching strategy (in order):
         1) Direct path exists
-        2) Exact sanitized filename match
-        3) Prefix-stripped sanitized filename exact match (strip: 강의자료/강의/lesson/lecture)
+        2) Exact sanitized filename match (unique only)
+        3) Prefix-stripped sanitized filename exact match (strip: 강의자료/강의/lesson/lecture; unique only)
         4) Exact sanitized stem match (unique only)
         5) Prefix-stripped sanitized stem exact match (unique only)
 
@@ -226,7 +226,7 @@ class PDFCreator:
             for p in files:
                 name_norm = self._normalize_korean(p.name)
                 name_key = re.sub(r"[\s_\-]+", "", name_norm).lower()
-                mapping_full[name_key] = p
+                mapping_full.setdefault(name_key, []).append(p)
                 # Stem without extension
                 stem_norm = self._normalize_korean(p.stem)
                 stem_key = re.sub(r"[\s_\-]+", "", stem_norm).lower()
@@ -237,7 +237,7 @@ class PDFCreator:
                 except Exception:
                     stripped_full_norm = name_norm
                 full_stripped_key = re.sub(r"[\s_\-]+", "", stripped_full_norm).lower()
-                mapping_full_stripped[full_stripped_key] = p
+                mapping_full_stripped.setdefault(full_stripped_key, []).append(p)
                 try:
                     stripped_stem_norm = re.sub(r"^(강의자료|강의|lesson|lecture)[\s_\-]+", "", stem_norm, flags=re.IGNORECASE)
                 except Exception:
@@ -272,17 +272,17 @@ class PDFCreator:
         needle_stem_stripped = _keyify(Path(_strip_prefix(lesson_filename) or '').stem)
 
         # 2) Exact sanitized filename match
-        candidate = mapping_full.get(needle_full)
-        if candidate and candidate.exists():
-            self.log_debug(f"Matched lesson file by exact full name: '{lesson_filename}' -> '{candidate.name}'")
-            return candidate
+        candidates = mapping_full.get(needle_full) or []
+        if len(candidates) == 1 and candidates[0].exists():
+            self.log_debug(f"Matched lesson file by exact full name: '{lesson_filename}' -> '{candidates[0].name}'")
+            return candidates[0]
 
         # 3) Prefix-stripped exact filename match
         if needle_full_stripped and needle_full_stripped != needle_full:
-            candidate = mapping_full_stripped.get(needle_full_stripped)
-            if candidate and candidate.exists():
-                self.log_debug(f"Matched by prefix-stripped full name: '{lesson_filename}' -> '{candidate.name}'")
-                return candidate
+            candidates = mapping_full_stripped.get(needle_full_stripped) or []
+            if len(candidates) == 1 and candidates[0].exists():
+                self.log_debug(f"Matched by prefix-stripped full name: '{lesson_filename}' -> '{candidates[0].name}'")
+                return candidates[0]
 
         # 4) Exact sanitized stem match (unique)
         if needle_stem:

--- a/tests/test_jokbo_resolution.py
+++ b/tests/test_jokbo_resolution.py
@@ -1,0 +1,28 @@
+import tempfile
+from pathlib import Path
+from pdf_creator import PDFCreator
+
+
+def test_resolve_jokbo_path_unique_sanitized_name():
+    creator = PDFCreator()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base = Path(tmpdir)
+        # Only one file that matches after sanitization
+        target = base / "exam 1.pdf"
+        target.write_bytes(b"")
+        resolved = creator._resolve_jokbo_path(str(base), "exam-1.pdf")
+        assert resolved == target
+        assert resolved.exists()
+
+
+def test_resolve_jokbo_path_ambiguous_collision():
+    creator = PDFCreator()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base = Path(tmpdir)
+        # Create two files that normalize to the same key
+        (base / "exam-1.pdf").write_bytes(b"")
+        (base / "exam 1.pdf").write_bytes(b"")
+        # Request a third variant that sanitizes to the same key but doesn't exist
+        resolved = creator._resolve_jokbo_path(str(base), "exam1.pdf")
+        assert resolved == base / "exam1.pdf"
+        assert not resolved.exists()

--- a/tests/test_lesson_resolution.py
+++ b/tests/test_lesson_resolution.py
@@ -1,0 +1,15 @@
+import tempfile
+from pathlib import Path
+from pdf_creator import PDFCreator
+
+def test_resolve_lesson_path_ambiguous_collision():
+    creator = PDFCreator()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        base = Path(tmpdir)
+        # Create two files that normalize to the same key
+        (base / "lecture-1.pdf").write_bytes(b"")
+        (base / "lecture 1.pdf").write_bytes(b"")
+        # Request a third variant that sanitizes to same key but doesn't exist
+        resolved = creator._resolve_lesson_path(str(base), "lecture1.pdf")
+        assert resolved == base / "lecture1.pdf"
+        assert not resolved.exists()


### PR DESCRIPTION
## Summary
- ensure `_resolve_jokbo_path` only matches when a sanitized jokbo name is unique to avoid cross-file page insertion
- document deterministic filename resolution for both lessons and jokbos
- add tests for unique and ambiguous jokbo filename resolution and allow tracked test files

## Testing
- `python -m py_compile pdf_creator.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afdd4f081c832bbe13901c9fd215d5