### PR TITLE
feat: enable admin cleanup of results

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -453,6 +453,7 @@
                     <label for="older_hours">Delete only files older than (hours)</label>
                     <input id="older_hours" type="number" min="1" placeholder="e.g. 168" style="width:140px;padding:0.5rem 0.75rem;border:1px solid var(--gray-300);border-radius:8px;" />
                     <button id="run_cleanup_btn" class="tab">Run Cleanup</button>
+                    <button id="run_full_cleanup_btn" class="tab">Run Cleanup + Results</button>
                     <button id="show_stats_btn" class="tab">Show Storage Stats</button>
                 </div>
                 <pre id="admin_output" style="margin-top:1rem;background:rgba(0,0,0,0.25);padding:0.75rem;border-radius:8px;max-height:240px;overflow:auto;color:#ccc;"></pre>
@@ -1125,7 +1126,7 @@
             if (input && input.value) return input.value;
             return saved;
         }
-        async function adminCleanup(olderHours = null) {
+        async function adminCleanup(olderHours = null, includeResults = false) {
             try {
                 const params = new URLSearchParams();
                 if (!CURRENT_USER || !CURRENT_USER.admin) {
@@ -1136,6 +1137,7 @@
                 params.set('clear_cache', 'true');
                 params.set('clear_debug', 'true');
                 params.set('clear_temp_sessions', 'true');
+                if (includeResults) params.set('clear_results', 'true');
                 if (olderHours && olderHours > 0) params.set('older_than_hours', String(olderHours));
                 const res = await fetch(`/admin/cleanup?${params.toString()}`, { method: 'POST', credentials: 'include' });
                 if (!res.ok) throw new Error('Cleanup request failed');
@@ -1172,6 +1174,12 @@
             const older = document.getElementById('older_hours').value;
             const n = older ? parseInt(older, 10) : null;
             adminCleanup(isNaN(n) ? null : n);
+        });
+        document.getElementById('run_full_cleanup_btn').addEventListener('click', () => {
+            const older = document.getElementById('older_hours').value;
+            const n = older ? parseInt(older, 10) : null;
+            if (!confirm('Delete all stored results? This cannot be undone.')) return;
+            adminCleanup(isNaN(n) ? null : n, true);
         });
         document.getElementById('show_stats_btn').addEventListener('click', async () => {
             const out = document.getElementById('admin_output');


### PR DESCRIPTION
## Summary
- allow admin cleanup endpoint to remove stored results first
- add front-end control to trigger result cleanup

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pdf_creator')*


------
https://chatgpt.com/codex/tasks/task_e_68c3a33daf04832ba1ee700fcbecc61c