### PR TITLE
fix: restore theme toggle and auth config messaging

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1473,6 +1473,7 @@
             }
         }
         document.getElementById('login_btn').addEventListener('click', async () => {
+            try { await fetchAuthConfig(); } catch {}
             if (AUTH_CONFIG.client_id) {
                 try {
                     setupGoogleSignIn();
@@ -1500,7 +1501,8 @@
                     await refreshAuthUI();
                 } catch (e) { alert('Dev login error: ' + e.message); }
             } else {
-                alert('Sign-in not configured. Please set GOOGLE_OAUTH_CLIENT_ID or enable dev login.');
+                const msg = (AUTH_CONFIG && AUTH_CONFIG.login_message) ? AUTH_CONFIG.login_message : 'Sign-in not configured.';
+                alert(msg);
             }
         });
         document.getElementById('logout_btn').addEventListener('click', async () => {

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -210,21 +210,38 @@
 
     document.getElementById('logout_btn').addEventListener('click', async () => { try { await fetch('/auth/logout', { method: 'POST', credentials: 'include' }); } catch {} location.href='/' });
     document.getElementById('login_btn').addEventListener('click', async () => {
-      try {
-        if (!AUTH_CONFIG.client_id) { alert('Sign-in not configured.'); return; }
-        setupGoogleSignIn();
-        /* global google */
-        google.accounts.id.prompt((notification) => {
-          const notShown = (typeof notification.isNotDisplayed === 'function' && notification.isNotDisplayed()) ||
-                           (typeof notification.isSkippedMoment === 'function' && notification.isSkippedMoment());
-          if (notShown) {
-            const btn = document.getElementById('gsi_btn');
-            if (btn) btn.style.display = 'inline-block';
-          }
-        });
-      } catch (e) {
-        const btn = document.getElementById('gsi_btn');
-        if (btn) btn.style.display = 'inline-block';
+      try { await fetchAuthConfig(); } catch {}
+      if (AUTH_CONFIG.client_id) {
+        try {
+          setupGoogleSignIn();
+          /* global google */
+          google.accounts.id.prompt((notification) => {
+            const notShown = (typeof notification.isNotDisplayed === 'function' && notification.isNotDisplayed()) ||
+                             (typeof notification.isSkippedMoment === 'function' && notification.isSkippedMoment());
+            if (notShown) {
+              const btn = document.getElementById('gsi_btn');
+              if (btn) btn.style.display = 'inline-block';
+            }
+          });
+        } catch (e) {
+          const btn = document.getElementById('gsi_btn');
+          if (btn) btn.style.display = 'inline-block';
+        }
+      } else if (AUTH_CONFIG.allow_dev_login) {
+        const email = prompt('Dev login email:');
+        if (!email) return;
+        const pw = prompt('Admin password for dev login:');
+        if (!pw) return;
+        try {
+          const r = await fetch('/auth/dev-login', { method: 'POST', credentials: 'include', headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, body: new URLSearchParams({ email, password: pw }) });
+          if (!r.ok) throw new Error('Dev login failed');
+          location.reload();
+        } catch (e) {
+          alert('Dev login error: ' + e.message);
+        }
+      } else {
+        const msg = (AUTH_CONFIG && AUTH_CONFIG.login_message) ? AUTH_CONFIG.login_message : 'Sign-in not configured.';
+        alert(msg);
       }
     });
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -76,6 +76,138 @@ html[data-theme="light"] {
   --gray-500: #6f8db6;
 }
 
+/* Tailwind utility overrides so light/dark themes remain in sync */
+html[data-theme] .text-white,
+html[data-theme] .text-gray-100,
+html[data-theme] .text-gray-200,
+html[data-theme] .text-gray-300 {
+  color: var(--color-text-primary) !important;
+}
+html[data-theme] .text-gray-400 {
+  color: var(--color-text-secondary) !important;
+}
+html[data-theme] .text-gray-500 {
+  color: var(--gray-500) !important;
+}
+html[data-theme] .text-gray-600,
+html[data-theme] .text-gray-700 {
+  color: var(--color-muted) !important;
+}
+html[data-theme] .bg-gray-900 {
+  background-color: var(--color-surface) !important;
+  color: var(--color-text-primary);
+}
+html[data-theme] .bg-gray-800,
+html[data-theme] .bg-gray-700 {
+  background-color: var(--color-surface-alt) !important;
+  color: var(--color-text-primary);
+}
+html[data-theme] .bg-gray-900\/70 {
+  background-color: var(--color-surface) !important;
+  background-color: color-mix(in srgb, var(--color-surface) 78%, transparent) !important;
+  color: var(--color-text-primary);
+}
+html[data-theme] .border-gray-700,
+html[data-theme] .border-gray-800 {
+  border-color: var(--color-border) !important;
+}
+html[data-theme] .hover\:bg-gray-700:hover,
+html[data-theme] .hover\:bg-gray-800:hover {
+  background-color: var(--control-surface-strong) !important;
+}
+
+select,
+input[type="text"],
+input[type="email"],
+input[type="password"],
+input[type="number"],
+textarea {
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  color: var(--color-text-primary);
+  padding: 0.65rem 0.9rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+select:focus,
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="password"]:focus,
+input[type="number"]:focus,
+textarea:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 2px var(--color-accent-soft);
+  outline: none;
+}
+
+input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--color-surface-contrast);
+  outline: none;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  border: 2px solid var(--color-bg);
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+input[type="range"]::-webkit-slider-thumb:hover {
+  transform: scale(1.05);
+}
+
+input[type="range"]::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  border: 2px solid var(--color-bg);
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+input[type="range"]::-moz-range-thumb:hover {
+  transform: scale(1.05);
+}
+
+input[type="range"]::-moz-range-track {
+  background: var(--color-surface-contrast);
+  height: 8px;
+  border-radius: 999px;
+}
+
+input[type="range"]::-ms-track {
+  background: transparent;
+  border-color: transparent;
+  color: transparent;
+}
+
+input[type="range"]::-ms-fill-lower,
+input[type="range"]::-ms-fill-upper {
+  background: var(--color-surface-contrast);
+  border-radius: 999px;
+}
+
+input[type="range"]::-ms-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  border: 2px solid var(--color-bg);
+  cursor: pointer;
+}
+
 * { box-sizing: border-box; }
 html, body { min-height: 100%; }
 body {

--- a/server/routes/auth.py
+++ b/server/routes/auth.py
@@ -89,15 +89,22 @@ def auth_config():
         initial_tokens = max(0, int(os.getenv("CBT_TOKENS_INITIAL", "200")))
     except Exception:
         initial_tokens = 200
+    client_id = os.getenv("GOOGLE_OAUTH_CLIENT_ID", "").strip()
+    allow_dev = os.getenv("ALLOW_DEV_LOGIN", "false").lower() in ("1", "true", "yes")
+    enabled = bool(client_id or allow_dev)
+    login_message = ""
+    if not enabled:
+        login_message = "Sign-in is not configured. Set GOOGLE_OAUTH_CLIENT_ID or enable dev login."
     return {
-        "enabled": True,
-        "client_id": os.getenv("GOOGLE_OAUTH_CLIENT_ID", ""),
-        "allow_dev_login": os.getenv("ALLOW_DEV_LOGIN", "false").lower() in ("1", "true", "yes"),
+        "enabled": enabled,
+        "client_id": client_id,
+        "allow_dev_login": allow_dev,
         "feedback_form_url": os.getenv("FEEDBACK_FORM_URL", ""),
         "tokens_enabled": True,
         "token_costs": {"flash": flash_cost, "pro": pro_cost},
         "initial_tokens": initial_tokens,
         "admin_login_via_google": bool(_admin_emails()),
+        "login_message": login_message,
     }
 
 


### PR DESCRIPTION
## Summary
- normalize Tailwind color utilities to theme-aware CSS variables so light/dark mode switches update all surfaces and controls
- style shared form inputs/range sliders with theme colours for consistent appearance
- surface real auth availability from /auth/config and refresh login flows to retry config fetches before showing fallback messages

## Testing
- python -m compileall server

------
https://chatgpt.com/codex/tasks/task_e_68c9f4632608832ba4a2e1cbf59cf565