### PR TITLE
fix: extend gemini request timeout defaults

### DIFF
--- a/config.py
+++ b/config.py
@@ -143,13 +143,13 @@ def build_generate_config(
 def build_client(api_key: Optional[str] = None) -> genai.Client:
     """Create a scoped google-genai Client with HTTP timeouts from env.
 
-    Honors GENAI_REQUEST_TIMEOUT_SECS if present; otherwise defaults to 300s.
+    Honors GENAI_REQUEST_TIMEOUT_SECS if present; otherwise defaults to 480s.
     """
     timeout_ms: int
     try:
-        timeout_ms = max(10, int(os.getenv("GENAI_REQUEST_TIMEOUT_SECS", "300"))) * 1000
+        timeout_ms = max(10, int(os.getenv("GENAI_REQUEST_TIMEOUT_SECS", "480"))) * 1000
     except Exception:
-        timeout_ms = 300_000
+        timeout_ms = 480_000
     http_opts = None
     try:
         if _genai_types is not None:

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -77,7 +77,7 @@ cp .env.example .env
   - Gemini 파일 업로드 RPC 하드 타임아웃. 단건 업로드 호출이 이 시간을 넘기면 실패 처리.
 - `GENAI_UPLOAD_ACTIVATION_TIMEOUT_SECS` (기본 300)
   - 업로드 후 파일 상태가 `ACTIVE`가 될 때까지의 최대 대기 시간.
-- `GENAI_REQUEST_TIMEOUT_SECS` (기본 300)
+- `GENAI_REQUEST_TIMEOUT_SECS` (기본 480)
   - `models.generateContent` 호출 하드 타임아웃. 무응답/네트워크 hang 방지.
 
 

--- a/pdf_processor/api/client.py
+++ b/pdf_processor/api/client.py
@@ -314,9 +314,9 @@ class GeminiAPIClient:
                 # Wrap the call with a hard timeout to avoid indefinite hangs
                 try:
                     try:
-                        req_timeout = max(10, int(os.getenv("GENAI_REQUEST_TIMEOUT_SECS", "300")))
+                        req_timeout = max(10, int(os.getenv("GENAI_REQUEST_TIMEOUT_SECS", "480")))
                     except Exception:
-                        req_timeout = 300
+                        req_timeout = 480
                     _executor = _fut.ThreadPoolExecutor(max_workers=1)
                     _timed_out = False
                     try:
@@ -340,9 +340,9 @@ class GeminiAPIClient:
                                 gen_kwargs["generation_config"] = final_gen_cfg
                             # Re-wrap with timeout for legacy path as well
                             try:
-                                req_timeout = max(10, int(os.getenv("GENAI_REQUEST_TIMEOUT_SECS", "300")))
+                                req_timeout = max(10, int(os.getenv("GENAI_REQUEST_TIMEOUT_SECS", "480")))
                             except Exception:
-                                req_timeout = 300
+                                req_timeout = 480
                             _executor = _fut.ThreadPoolExecutor(max_workers=1)
                             _timed_out2 = False
                             try:
@@ -363,9 +363,9 @@ class GeminiAPIClient:
                                 gen_kwargs.pop("safety_settings", None)
                                 # Timeout-guarded call again
                             try:
-                                req_timeout = max(10, int(os.getenv("GENAI_REQUEST_TIMEOUT_SECS", "300")))
+                                req_timeout = max(10, int(os.getenv("GENAI_REQUEST_TIMEOUT_SECS", "480")))
                             except Exception:
-                                req_timeout = 300
+                                req_timeout = 480
                                 _executor = _fut.ThreadPoolExecutor(max_workers=1)
                                 _timed_out3 = False
                                 try:
@@ -385,9 +385,9 @@ class GeminiAPIClient:
                     elif "unexpected keyword" in msg and "safety_settings" in msg:
                         gen_kwargs.pop("safety_settings", None)
                         try:
-                            req_timeout = max(10, int(os.getenv("GENAI_REQUEST_TIMEOUT_SECS", "300")))
+                            req_timeout = max(10, int(os.getenv("GENAI_REQUEST_TIMEOUT_SECS", "480")))
                         except Exception:
-                            req_timeout = 300
+                            req_timeout = 480
                         _executor = _fut.ThreadPoolExecutor(max_workers=1)
                         _timed_out4 = False
                         try:


### PR DESCRIPTION
## Summary
- raise the default `GENAI_REQUEST_TIMEOUT_SECS` from 300s to 480s for Gemini content generation
- update the shared client factory and configuration docs to reflect the longer timeout

## Testing
- not run (config-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cf9976d6a4832b86ca534bcb0a0ff5