### PR TITLE
fix: improve upload cleanup and admin tooling

### DIFF
--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -30,6 +30,7 @@ cp .env.example .env
   - `RESULT_RETENTION_HOURS` (기본 720)
   - `SESSIONS_RETENTION_HOURS` (기본 168)
   - `TMP_RETENTION_HOURS` (기본 24, 워커 임시 디렉토리 정리)
+  - `UPLOAD_RETENTION_HOURS` (기본 48, 업로드 원본 정리)
 
 - 워커 디스크 사용 제어(권장)
   - `PERSIST_RESULTS_ON_DISK`

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -452,9 +452,10 @@
                 </div>
                 <div class="form-section" style="display:flex;gap:0.75rem;flex-wrap:wrap;align-items:center;margin-top:0.75rem;">
                     <label for="older_hours">Delete only files older than (hours)</label>
-                    <input id="older_hours" type="number" min="1" placeholder="e.g. 168" style="width:140px;padding:0.5rem 0.75rem;border:1px solid var(--gray-300);border-radius:8px;" />
+                    <input id="older_hours" type="number" min="0" placeholder="e.g. 168 (0 = delete all)" style="width:140px;padding:0.5rem 0.75rem;border:1px solid var(--gray-300);border-radius:8px;" />
                     <button id="run_cleanup_btn" class="tab">Run Cleanup</button>
                     <button id="run_full_cleanup_btn" class="tab">Run Cleanup + Results</button>
+                    <button id="run_upload_cleanup_btn" class="tab" title="Remove uploaded sources after jobs finish">Purge Uploads</button>
                     <button id="worker_cleanup_btn" class="tab" title="Trigger cleanup on workers">Worker Cleanup Now</button>
                     <button id="show_stats_btn" class="tab">Show Web Storage Stats</button>
                     <button id="show_worker_stats_btn" class="tab">Show Worker Storage Stats</button>
@@ -1253,7 +1254,16 @@
             if (input && input.value) return input.value;
             return saved;
         }
-        async function adminCleanup(olderHours = null, includeResults = false) {
+        async function adminCleanup(options = {}) {
+            const {
+                olderHours = null,
+                includeResults = false,
+                includeUploads = false,
+                purgeAllUploads = false,
+                clearCache = true,
+                clearDebug = true,
+                clearTempSessions = true,
+            } = options ?? {};
             try {
                 const params = new URLSearchParams();
                 if (!CURRENT_USER || !CURRENT_USER.admin) {
@@ -1261,11 +1271,15 @@
                     if (!pw) { alert('Enter Admin Password in the Admin Tools section first.'); return; }
                     params.set('password', pw);
                 }
-                params.set('clear_cache', 'true');
-                params.set('clear_debug', 'true');
-                params.set('clear_temp_sessions', 'true');
-                if (includeResults) params.set('clear_results', 'true');
-                if (olderHours && olderHours > 0) params.set('older_than_hours', String(olderHours));
+                params.set('clear_cache', String(!!clearCache));
+                params.set('clear_debug', String(!!clearDebug));
+                params.set('clear_temp_sessions', String(!!clearTempSessions));
+                params.set('clear_results', String(!!includeResults));
+                if (includeUploads) params.set('clear_uploads', 'true');
+                if (purgeAllUploads) params.set('purge_all_uploads', 'true');
+                if (olderHours !== null && !Number.isNaN(olderHours) && olderHours >= 0) {
+                    params.set('older_than_hours', String(olderHours));
+                }
                 const res = await fetch(`/admin/cleanup?${params.toString()}`, { method: 'POST', credentials: 'include' });
                 if (!res.ok) throw new Error('Cleanup request failed');
                 const data = await res.json();
@@ -1281,8 +1295,12 @@
         document.getElementById('clear_cache_btn').addEventListener('click', (e) => {
             e.preventDefault();
             const older = prompt('Delete only files older than N hours? (Leave empty for all)', '');
-            const n = older ? parseInt(older, 10) : null;
-            adminCleanup(isNaN(n) ? null : n);
+            let n = null;
+            if (older !== null && older.trim() !== '') {
+                const parsed = parseInt(older.trim(), 10);
+                if (!Number.isNaN(parsed) && parsed >= 0) n = parsed;
+            }
+            adminCleanup({ olderHours: n });
         });
 
         // Admin tools wiring
@@ -1299,14 +1317,40 @@
         });
         document.getElementById('run_cleanup_btn').addEventListener('click', () => {
             const older = document.getElementById('older_hours').value;
-            const n = older ? parseInt(older, 10) : null;
-            adminCleanup(isNaN(n) ? null : n);
+            let n = null;
+            if (older !== '') {
+                const parsed = parseInt(older, 10);
+                if (!Number.isNaN(parsed) && parsed >= 0) n = parsed;
+            }
+            adminCleanup({ olderHours: n });
         });
         document.getElementById('run_full_cleanup_btn').addEventListener('click', () => {
             const older = document.getElementById('older_hours').value;
-            const n = older ? parseInt(older, 10) : null;
+            let n = null;
+            if (older !== '') {
+                const parsed = parseInt(older, 10);
+                if (!Number.isNaN(parsed) && parsed >= 0) n = parsed;
+            }
             if (!confirm('Delete all stored results? This cannot be undone.')) return;
-            adminCleanup(isNaN(n) ? null : n, true);
+            adminCleanup({ olderHours: n, includeResults: true });
+        });
+        document.getElementById('run_upload_cleanup_btn').addEventListener('click', () => {
+            const olderValue = document.getElementById('older_hours').value;
+            let n = null;
+            if (olderValue !== '') {
+                const parsed = parseInt(olderValue, 10);
+                if (!Number.isNaN(parsed) && parsed >= 0) n = parsed;
+            }
+            const purgeAll = n === 0;
+            if (purgeAll && !confirm('Delete ALL stored uploads (Redis/local/object store)? This cannot be undone.')) return;
+            adminCleanup({
+                olderHours: n,
+                includeUploads: true,
+                purgeAllUploads: purgeAll,
+                clearCache: false,
+                clearDebug: false,
+                clearTempSessions: false,
+            });
         });
         document.getElementById('worker_cleanup_btn').addEventListener('click', async () => {
             try {

--- a/server/routes/misc.py
+++ b/server/routes/misc.py
@@ -103,17 +103,21 @@ from .auth import get_current_user as _get_current_user  # lazy import to avoid 
 
 @router.post("/admin/cleanup")
 def admin_cleanup(
+    request: Request,
     password: Optional[str] = Query(None),
     clear_cache: bool = Query(True),
     clear_debug: bool = Query(True),
     clear_temp_sessions: bool = Query(True),
     clear_results: bool = Query(False),
-    older_than_hours: int | None = Query(None, ge=1, description="Only delete files older than this many hours"),
+    clear_uploads: bool = Query(False, description="Purge stored uploads (Redis/local/object store)."),
+    older_than_hours: int | None = Query(None, ge=0, description="Only delete files older than this many hours (0 deletes immediately)"),
+    purge_all_uploads: bool = Query(False, description="Force delete all uploads regardless of age."),
     user=Depends(_get_current_user),
 ):
     """Administrative cleanup: clear cache, results, and debug/temp files."""
     _require_admin(password, user)
-    summary: dict[str, dict | bool] = {}
+    summary: dict[str, dict | bool | list | None] = {}
+    storage_manager = getattr(request.app.state, "storage_manager", None)
     if clear_results:
         try:
             base_storage = Path(os.getenv("RENDER_STORAGE_PATH", "output"))
@@ -137,6 +141,20 @@ def admin_cleanup(
             summary["temp_sessions_deleted"] = delete_path_contents(Path("output/temp/sessions"), older_than_hours)
         except Exception as e:
             summary["temp_sessions_deleted"] = {"error": str(e)}
+    if clear_uploads:
+        if storage_manager is None:
+            summary["uploads_deleted"] = {"error": "storage manager unavailable"}
+        else:
+            try:
+                delete_all_flag = bool(purge_all_uploads)
+                if older_than_hours is not None and older_than_hours == 0:
+                    delete_all_flag = True
+                summary["uploads_deleted"] = storage_manager.purge_stale_uploads(
+                    older_than_hours=older_than_hours,
+                    delete_all=delete_all_flag,
+                )
+            except Exception as e:
+                summary["uploads_deleted"] = {"error": str(e)}
     return summary
 
 

--- a/storage_manager.py
+++ b/storage_manager.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import List, Dict, Optional
 import hashlib
 import socket
-from datetime import datetime
+from datetime import datetime, timezone
 
 S3ObjectStore = None  # type: ignore
 _S3_IMPORT_ERROR: Optional[str] = None
@@ -825,6 +825,231 @@ class StorageManager:
                 summary["local_deleted"] = True
             except Exception as e:
                 summary["local_error"] = str(e)
+        return summary
+
+    def purge_stale_uploads(
+        self,
+        older_than_hours: Optional[int] = None,
+        *,
+        delete_all: bool = False,
+    ) -> Dict[str, object]:
+        """Best-effort purge of uploads that no longer belong to active jobs.
+
+        This scans Redis, local storage, and the optional object store for
+        uploads grouped by job id. Jobs whose most recent upload is older than
+        ``older_than_hours`` (or all jobs when ``delete_all`` is True) are
+        removed. Active jobs (status RUNNING/QUEUED) are skipped to avoid
+        interfering with in-flight work.
+        """
+
+        summary: Dict[str, object] = {
+            "threshold_hours": None,
+            "delete_all": bool(delete_all),
+            "jobs_considered": 0,
+            "jobs_purged": [],
+            "jobs_skipped": [],
+            "redis_keys_deleted": 0,
+            "local_dirs_deleted": 0,
+            "s3_prefixes_deleted": 0,
+            "s3_objects_deleted": 0,
+        }
+
+        threshold_hours: Optional[int]
+        if delete_all:
+            threshold_hours = None
+        else:
+            if older_than_hours is not None:
+                try:
+                    threshold_hours = max(0, int(older_than_hours))
+                except Exception:
+                    threshold_hours = 0
+            else:
+                try:
+                    threshold_hours = max(0, int(os.getenv("UPLOAD_RETENTION_HOURS", "48")))
+                except Exception:
+                    threshold_hours = 48
+        summary["threshold_hours"] = threshold_hours
+        threshold_seconds: Optional[float]
+        if threshold_hours is None:
+            threshold_seconds = None
+        else:
+            threshold_seconds = float(threshold_hours * 3600)
+
+        now_dt = datetime.now(timezone.utc)
+        now_ts = time.time()
+
+        job_info: Dict[str, Dict[str, object]] = {}
+
+        # Collect Redis keys per job to determine age and candidates.
+        if not self.use_local_only and self.redis_client:
+            try:
+                for key in self.redis_client.scan_iter(match="file:*"):
+                    key_str = key.decode() if isinstance(key, (bytes, bytearray)) else str(key)
+                    parts = key_str.split(":")
+                    if len(parts) < 2:
+                        continue
+                    job_id = parts[1]
+                    try:
+                        ttl = self.redis_client.ttl(key_str)
+                    except Exception:
+                        ttl = None
+                    if ttl is None:
+                        age_seconds = None
+                    elif ttl < 0:
+                        age_seconds = float(self.file_ttl_seconds)
+                    else:
+                        age_seconds = float(max(0, self.file_ttl_seconds - int(ttl)))
+                    info = job_info.setdefault(job_id, {})
+                    keys = info.setdefault("redis_keys", [])
+                    keys.append(key_str)
+                    info["redis_count"] = int(info.get("redis_count", 0)) + 1
+                    if age_seconds is not None:
+                        current = float(info.get("redis_max_age", 0.0))
+                        if age_seconds > current:
+                            info["redis_max_age"] = age_seconds
+            except Exception as e:
+                summary["redis_error"] = str(e)
+        else:
+            summary["redis_note"] = "redis unavailable"
+
+        # Collect local storage directories per job.
+        try:
+            for entry in self.local_storage.iterdir():
+                try:
+                    if not entry.is_dir():
+                        continue
+                    job_id = entry.name
+                    info = job_info.setdefault(job_id, {})
+                    info["local_path"] = entry
+                    try:
+                        mtime = entry.stat().st_mtime
+                        info["local_age"] = max(0.0, now_ts - mtime)
+                    except Exception:
+                        info["local_age"] = None
+                except Exception:
+                    continue
+        except FileNotFoundError:
+            pass
+        except Exception:
+            summary["local_error"] = "failed to scan local storage"
+
+        # Collect object store uploads metadata.
+        def _parse_dt(val) -> Optional[datetime]:
+            if isinstance(val, datetime):
+                return val.astimezone(timezone.utc) if val.tzinfo else val.replace(tzinfo=timezone.utc)
+            if isinstance(val, str):
+                try:
+                    s = val[:-1] + "+00:00" if val.endswith("Z") else val
+                    dt = datetime.fromisoformat(s)
+                    if dt.tzinfo is None:
+                        dt = dt.replace(tzinfo=timezone.utc)
+                    return dt.astimezone(timezone.utc)
+                except Exception:
+                    return None
+            return None
+
+        if self._s3 is not None:
+            try:
+                objects = self._s3.list_objects("uploads/")
+                for obj in objects:
+                    key = obj.get("key")
+                    if not key or not key.startswith("uploads/"):
+                        continue
+                    parts = key.split("/")
+                    if len(parts) < 3:
+                        continue
+                    job_id = parts[1]
+                    info = job_info.setdefault(job_id, {})
+                    info["s3_count"] = int(info.get("s3_count", 0)) + 1
+                    dt = _parse_dt(obj.get("last_modified"))
+                    if dt is not None:
+                        current = info.get("s3_latest")
+                        if not isinstance(current, datetime) or dt > current:
+                            info["s3_latest"] = dt
+            except Exception as e:
+                summary["s3_error"] = str(e)
+        else:
+            summary["s3_note"] = "object store disabled"
+
+        summary["jobs_considered"] = len(job_info)
+
+        for job_id, info in job_info.items():
+            max_age = 0.0
+            redis_age = float(info.get("redis_max_age", 0.0))
+            if redis_age > max_age:
+                max_age = redis_age
+            local_age = info.get("local_age")
+            if isinstance(local_age, (int, float)) and local_age > max_age:
+                max_age = float(local_age)
+            latest = info.get("s3_latest")
+            if isinstance(latest, datetime):
+                try:
+                    s3_age = max(0.0, (now_dt - latest).total_seconds())
+                    if s3_age > max_age:
+                        max_age = s3_age
+                except Exception:
+                    pass
+
+            should_delete = delete_all
+            if not should_delete and threshold_seconds is not None:
+                if max_age >= threshold_seconds:
+                    should_delete = True
+
+            if not should_delete:
+                continue
+
+            is_active = False
+            if not delete_all:
+                try:
+                    status = self.get_job_status(job_id)
+                    if status and str(status.get("status", "")).upper() in {"RUNNING", "QUEUED"}:
+                        is_active = True
+                except Exception:
+                    is_active = False
+            if is_active:
+                if job_id not in summary["jobs_skipped"]:
+                    summary["jobs_skipped"].append(job_id)
+                continue
+
+            removed_any = False
+
+            redis_keys = info.get("redis_keys") or []
+            if redis_keys and not self.use_local_only and self.redis_client:
+                for key_str in redis_keys:
+                    try:
+                        self._with_retry(self.redis_client.delete, key_str)
+                        summary["redis_keys_deleted"] += 1
+                        removed_any = True
+                    except Exception:
+                        continue
+
+            local_path = info.get("local_path")
+            if local_path:
+                try:
+                    import shutil
+                    shutil.rmtree(local_path, ignore_errors=True)
+                    summary["local_dirs_deleted"] += 1
+                    removed_any = True
+                except Exception:
+                    pass
+
+            if info.get("s3_count") and self._s3 is not None:
+                try:
+                    deleted = int(self._s3.delete_prefix(f"uploads/{job_id}/"))
+                    if deleted > 0:
+                        summary["s3_prefixes_deleted"] += 1
+                        summary["s3_objects_deleted"] += deleted
+                        removed_any = True
+                except Exception as e:
+                    errs = summary.setdefault("s3_delete_errors", [])
+                    errs.append({job_id: str(e)})
+
+            if removed_any:
+                summary["jobs_purged"].append(job_id)
+            else:
+                if job_id not in summary["jobs_skipped"]:
+                    summary["jobs_skipped"].append(job_id)
+
         return summary
 
     def job_storage_summary(self, job_id: str, include_objects: bool = False) -> Dict[str, object]:

--- a/tasks.py
+++ b/tasks.py
@@ -466,8 +466,14 @@ def _prune_path(base: Path, older_than_hours: int | None) -> None:
             pass
 
 
-def _cleanup_once(*, debug_hours: int | None = None, results_hours: int | None = None,
-                  sessions_hours: int | None = None, tmp_hours: int | None = None) -> None:
+def _cleanup_once(
+    *,
+    debug_hours: int | None = None,
+    results_hours: int | None = None,
+    sessions_hours: int | None = None,
+    tmp_hours: int | None = None,
+    uploads_hours: int | None = None,
+) -> None:
     """One-shot cleanup pass for worker-side storage paths.
 
     Optional args override env defaults. Use 0 for immediate deletion.
@@ -491,6 +497,7 @@ def _cleanup_once(*, debug_hours: int | None = None, results_hours: int | None =
                 sessions_hours = 72
 
         # Paths to clean
+        sm: Optional[StorageManager] = None
         try:
             sm = StorageManager()
             results_root = getattr(sm, "results_dir", Path(os.getenv("RENDER_STORAGE_PATH", "output")) / "results")
@@ -501,6 +508,18 @@ def _cleanup_once(*, debug_hours: int | None = None, results_hours: int | None =
         debug_dir = Path("output/debug")
         sessions_dir = Path("output/temp/sessions")
         tmpdir = Path(os.getenv("TMPDIR", tempfile.gettempdir()))
+
+        uploads_hours_eff = uploads_hours
+        if uploads_hours_eff is None:
+            try:
+                uploads_hours_eff = int(os.getenv("UPLOAD_RETENTION_HOURS", "48"))
+            except Exception:
+                uploads_hours_eff = 48
+        if sm is not None:
+            try:
+                sm.purge_stale_uploads(older_than_hours=max(0, int(uploads_hours_eff)))
+            except Exception:
+                pass
 
         _prune_path(debug_dir, debug_hours)
         _prune_path(sessions_dir, sessions_hours)
@@ -575,7 +594,7 @@ def worker_cleanup_now(older_hours: int | None = None) -> dict:
         if oh is None:
             _cleanup_once()
         else:
-            _cleanup_once(debug_hours=oh, results_hours=oh, sessions_hours=oh, tmp_hours=oh)
+            _cleanup_once(debug_hours=oh, results_hours=oh, sessions_hours=oh, tmp_hours=oh, uploads_hours=oh)
         return {"status": "ok", "older_hours": oh}
     except Exception as e:
         return {"status": "error", "error": str(e)}


### PR DESCRIPTION
## Summary
- add `StorageManager.purge_stale_uploads` to retire stale uploads across Redis, disk, and object storage with retention controls
- run the new purge inside worker cleanup and expose admin toggles plus UI to trigger upload cleanup or full deletions
- document the new `UPLOAD_RETENTION_HOURS` knob for operators

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfd88cff48832b97b352fd6996581b