### PR TITLE
fix: display original filenames in generated PDFs

### DIFF
--- a/pdf_creator.py
+++ b/pdf_creator.py
@@ -306,6 +306,39 @@ class PDFCreator:
         normalized = self._normalize_korean(name)
         return self._insert_soft_breaks(normalized)
 
+    def _resolve_display_override(self, name: str, overrides: Optional[Dict[str, str]]) -> str:
+        """Return the preferred display name using override mappings when provided."""
+        if not name or not overrides:
+            return name
+        candidates = [name]
+        try:
+            base = Path(name).name
+            if base not in candidates:
+                candidates.append(base)
+            try:
+                stripped = re.sub(r"^(?:jokbo|lesson|족보|강의자료)[\s_\-]+", "", base, flags=re.IGNORECASE)
+            except re.error:
+                stripped = base
+            if stripped and stripped not in candidates:
+                candidates.append(stripped)
+        except Exception:
+            pass
+        for cand in candidates:
+            if cand in overrides:
+                return overrides[cand]
+            try:
+                normalized = self._normalize_korean(cand)
+                if normalized in overrides:
+                    return overrides[normalized]
+            except Exception:
+                pass
+        return name
+
+    def _format_with_overrides(self, name: str, overrides: Optional[Dict[str, str]]) -> str:
+        """Format a filename for display, applying overrides when available."""
+        resolved = self._resolve_display_override(name, overrides)
+        return self._format_display_filename(resolved)
+
     @staticmethod
     def _safe_int(value, default: int = 0) -> int:
         """Coerce common stringy numbers like "12", "p12", "12-13" to an int (first number)."""
@@ -889,8 +922,13 @@ class PDFCreator:
         
         doc = fitz.open()
         lesson_pdf = fitz.open(lesson_path)
+        overrides = analysis_result.get("_display_name_overrides") or {}
+        lesson_overrides = overrides.get("lesson") or {}
+        jokbo_overrides = overrides.get("jokbo") or {}
         lesson_basename = Path(lesson_path).name
-        display_lesson_basename = self._format_display_filename(lesson_basename)
+        primary_display = analysis_result.get("_primary_display_name")
+        lesson_display_name = primary_display or self._resolve_display_override(lesson_basename, lesson_overrides)
+        display_lesson_basename = self._format_display_filename(lesson_display_name)
 
         # Build an index of related questions by lesson page
         related_by_page: Dict[int, List[Dict[str, Any]]] = {}
@@ -962,7 +1000,8 @@ class PDFCreator:
                 explanation_page = doc.new_page()
                 text_content = f"=== 문제 {question.get('question_number')} 해설 ===\n\n"
                 text_content += f"※ 앞 페이지의 문제 {question.get('question_number')}번을 참고하세요\n\n"
-                src_name = self._format_display_filename(str(question.get('jokbo_filename') or ''))
+                raw_jokbo_name = str(question.get('jokbo_filename') or '')
+                src_name = self._format_with_overrides(raw_jokbo_name, jokbo_overrides)
                 text_content += f"[출처: {src_name} - {question.get('jokbo_page')}페이지]\n\n"
                 # Slide-level importance score (if available)
                 if page_num in importance_by_page:
@@ -1093,8 +1132,13 @@ class PDFCreator:
             return
         
         doc = fitz.open()
+        overrides = analysis_result.get("_display_name_overrides") or {}
+        lesson_overrides = overrides.get("lesson") or {}
+        jokbo_overrides = overrides.get("jokbo") or {}
         jokbo_filename = Path(jokbo_path).name
-        display_jokbo_filename = self._format_display_filename(jokbo_filename)
+        primary_display = analysis_result.get("_primary_display_name")
+        jokbo_display_name = primary_display or self._resolve_display_override(jokbo_filename, jokbo_overrides)
+        display_jokbo_filename = self._format_display_filename(jokbo_display_name)
         
         # Get PDF page count thread-safely
         jokbo_pdf = self.get_jokbo_pdf(jokbo_path)  # get_jokbo_pdf already handles locking
@@ -1265,7 +1309,7 @@ class PDFCreator:
                 text_content += "관련 강의 슬라이드:\n"
                 for i, slide_info in enumerate(related_slides, 1):
                     # Defensive fetches
-                    fname = self._format_display_filename(slide_info.get('lesson_filename') or 'Unknown.pdf')
+                    fname = self._format_with_overrides(slide_info.get('lesson_filename') or 'Unknown.pdf', lesson_overrides)
                     page_no = slide_info.get('lesson_page')
                     score = slide_info.get('relevance_score')
                     if score is None:

--- a/tasks.py
+++ b/tasks.py
@@ -1,5 +1,6 @@
 # tasks.py
 import os
+import re
 import tempfile
 from pathlib import Path
 import pymupdf as fitz
@@ -97,6 +98,9 @@ def run_analysis_task(job_id: str, model_type: Optional[str], multi_api: Optiona
 
         jokbo_keys = metadata["jokbo_keys"]
         lesson_keys = metadata["lesson_keys"]
+        originals = metadata.get("original_filenames") if isinstance(metadata, dict) else None
+        original_jokbo_names = list((originals or {}).get("jokbo") or [])
+        original_lesson_names = list((originals or {}).get("lesson") or [])
         primary_keys = jokbo_keys if strategy.primary_kind == "jokbo" else lesson_keys
         secondary_keys = lesson_keys if strategy.secondary_kind == "lesson" else jokbo_keys
 
@@ -131,13 +135,14 @@ def run_analysis_task(job_id: str, model_type: Optional[str], multi_api: Optiona
             lesson_dir.mkdir(parents=True, exist_ok=True)
             output_dir.mkdir(parents=True, exist_ok=True)
 
-            def _plan_downloads(keys: list[str], base_dir: Path) -> list[dict]:
+            def _plan_downloads(keys: list[str], base_dir: Path, original_names: list[str]) -> list[dict]:
                 plan: list[dict] = []
                 for idx, key in enumerate(keys):
                     parts = key.split(":")
                     filename = parts[-2] if len(parts) >= 2 else f"file_{idx}"
                     local_path = base_dir / filename
-                    plan.append({"key": key, "path": local_path, "name": filename})
+                    original_name = original_names[idx] if idx < len(original_names) else None
+                    plan.append({"key": key, "path": local_path, "name": filename, "original_name": original_name})
                 return plan
 
             def _ensure_local(entry: dict) -> Path:
@@ -150,19 +155,41 @@ def run_analysis_task(job_id: str, model_type: Optional[str], multi_api: Optiona
                     storage_manager.save_file_locally(entry["key"], path)
                 return path
 
-            jokbo_plan = _plan_downloads(list(jokbo_keys), jokbo_dir)
-            lesson_plan = _plan_downloads(list(lesson_keys), lesson_dir)
+            jokbo_plan = _plan_downloads(list(jokbo_keys), jokbo_dir, original_jokbo_names)
+            lesson_plan = _plan_downloads(list(lesson_keys), lesson_dir, original_lesson_names)
+
+            def _add_override(overrides: dict[str, str], stored_name: str, original_name: Optional[str]) -> None:
+                if not stored_name or not original_name:
+                    return
+                keys = {stored_name, Path(stored_name).name}
+                try:
+                    stripped = re.sub(r"^(?:jokbo|lesson|족보|강의자료)[\s_\-]+", "", Path(stored_name).name, flags=re.IGNORECASE)
+                except re.error:
+                    stripped = Path(stored_name).name
+                if stripped:
+                    keys.add(stripped)
+                for key in keys:
+                    overrides[key] = original_name
 
             # Lessons are needed for chunk estimation regardless of mode.
             lesson_paths: list[str] = []
+            lesson_display_map: dict[str, str] = {}
             for entry in lesson_plan:
                 lesson_paths.append(str(_ensure_local(entry)))
+                _add_override(lesson_display_map, entry.get("name") or "", entry.get("original_name"))
 
             jokbo_paths: list[str]
+            jokbo_display_map: dict[str, str] = {}
             if strategy.secondary_kind == "jokbo":
-                jokbo_paths = [str(_ensure_local(entry)) for entry in jokbo_plan]
+                jokbo_paths = []
+                for entry in jokbo_plan:
+                    jokbo_paths.append(str(_ensure_local(entry)))
+                    _add_override(jokbo_display_map, entry.get("name") or "", entry.get("original_name"))
             else:
-                jokbo_paths = [str(entry["path"]) for entry in jokbo_plan]
+                jokbo_paths = []
+                for entry in jokbo_plan:
+                    jokbo_paths.append(str(entry["path"]))
+                    _add_override(jokbo_display_map, entry.get("name") or "", entry.get("original_name"))
 
             primary_plan = jokbo_plan if strategy.primary_kind == "jokbo" else lesson_plan
             primary_paths = [str(entry["path"]) for entry in primary_plan]
@@ -265,6 +292,16 @@ def run_analysis_task(job_id: str, model_type: Optional[str], multi_api: Optiona
                         aggregated_warnings["failed_chunks"] += int(w.get("failed_chunks"))
                 except Exception:
                     pass
+
+                analysis_result["_display_name_overrides"] = {
+                    "lesson": dict(lesson_display_map),
+                    "jokbo": dict(jokbo_display_map),
+                }
+                primary_display = entry.get("original_name")
+                if primary_display:
+                    analysis_result["_primary_display_name"] = primary_display
+                else:
+                    analysis_result.pop("_primary_display_name", None)
 
                 # PDF generation message
                 try:


### PR DESCRIPTION
## Summary
- preserve the original jokbo and lesson filenames when planning downloads and attach them to each analysis result
- teach PDFCreator to honor filename overrides so the generated explanation pages show the uploaded names instead of internal IDs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4b8bf17dc832ba083a19d0c4b0ecd