### PR TITLE
feat: switch to post-usage JD token billing

### DIFF
--- a/frontend/guide.html
+++ b/frontend/guide.html
@@ -124,7 +124,7 @@
           'Partial Jokbo creates a sharp cram sheet with cropped questions.',
           'Exam Only exports a polished jokbo without lecture matches.'
         ],
-        heroNote: 'Every mode shares the same 100 MB upload limit and token billing. Multi-API still works when multiple Gemini keys are configured.',
+        heroNote: 'Every mode shares the same 100 MB upload limit. JD tokens are charged after completion based on actual Gemini usage metadata.',
         heroCta: 'Open quick start',
         tabLabel: 'Guide sections',
         tabHint: 'Tip: switch tabs or language without losing your place.',
@@ -202,7 +202,7 @@
             },
             {
               title: 'Review the preflight summary',
-              description: 'Check how many pages and chunks will run. Cancel or continue before tokens are consumed.'
+              description: 'Check how many pages and chunks will run. Confirm when ready—JD tokens are deducted only after the job finishes.'
             },
             {
               title: 'Track progress & download',
@@ -213,7 +213,7 @@
           reminders: [
             'Uploads must stay under 100 MB per PDF.',
             'Jobs keep running in the background. Reopen My Jobs to fetch the final files.',
-            'Gemini Flash costs 1 token per chunk, Pro uses 4 tokens — check the profile page for your balance.'
+            'JD tokens are calculated from Gemini usage metadata — check the result card after each job to see the actual amount consumed.'
           ]
         },
         tips: {
@@ -240,7 +240,7 @@
               title: 'Operations',
               items: [
                 'Use My Jobs to re-download completed outputs or clean up files you no longer need.',
-                'Cancel jobs from the status card or profile page to stop remaining chunks without burning extra tokens.',
+                'Cancel jobs from the status card or profile page to stop remaining chunks and prevent additional JD token usage.',
                 'Admins can monitor quota with /admin/storage-stats and trigger /admin/cleanup when needed.'
               ]
             }
@@ -260,11 +260,11 @@
             },
             {
               q: 'What if the run is blocked or fails?',
-              a: 'We surface Gemini safety blocks immediately. Adjust the content, lower minimum relevance, or split the PDF and try again. Tokens are only deducted for completed chunks.'
+              a: 'We surface Gemini safety blocks immediately. Adjust the content, lower minimum relevance, or split the PDF and try again. JD tokens are only deducted for work that already ran.'
             },
             {
               q: 'Can I cancel a job mid-run?',
-              a: 'Yes. Use the Cancel button on the status card or under My Jobs → Job details. Remaining chunks stop and no extra tokens are spent.'
+              a: 'Yes. Use the Cancel button on the status card or under My Jobs → Job details. Remaining chunks stop and no additional JD tokens are charged.'
             }
           ]
         },
@@ -281,7 +281,7 @@
           'Partial Jokbo 모드는 잘린 문제 요약으로 벼락치기용 요약을 만듭니다.',
           'Exam Only 모드는 강의 매칭 없이 깔끔한 족보만 출력합니다.'
         ],
-        heroNote: '모든 모드는 PDF 당 100MB 업로드 제한과 동일한 토큰 규칙을 따릅니다. 여러 Gemini 키가 설정된 경우 Multi-API도 계속 병렬로 동작합니다.',
+        heroNote: '모든 모드는 PDF 당 100MB 업로드 제한을 공유합니다. 작업이 완료되면 Gemini usage_metadata를 환산해 JD 토큰이 차감됩니다.',
         heroCta: '빠른 시작 열기',
         tabLabel: '가이드 섹션',
         tabHint: 'Tip: 언어를 바꿔도 현재 탭과 위치는 유지됩니다.',
@@ -359,7 +359,7 @@
             },
             {
               title: '4. 사전 점검 확인',
-              description: '처리 예정 페이지와 청크 수를 먼저 보여줍니다. 토큰이 사용되기 전에 취소하거나 진행을 결정하세요.'
+              description: '처리 예정 페이지와 청크 수를 먼저 보여줍니다. 준비가 되면 진행을 확정하세요. JD 토큰은 작업 완료 후 실제 사용량을 기준으로 차감됩니다.'
             },
             {
               title: '5. 진행 상황 확인 & 다운로드',
@@ -370,7 +370,7 @@
           reminders: [
             'PDF는 파일당 100MB 이하만 업로드할 수 있습니다.',
             '작업은 백그라운드에서 계속 진행됩니다. My Jobs에서 다시 열어 결과를 내려받으세요.',
-            'Gemini Flash는 청크당 1토큰, Pro는 4토큰을 사용합니다. 잔액은 프로필 페이지에서 확인하세요.'
+            'JD 토큰은 Gemini usage_metadata를 환산해 계산됩니다. 작업 완료 후 결과 카드에서 실제 사용량을 확인하세요.'
           ]
         },
         tips: {
@@ -397,7 +397,7 @@
               title: '운영',
               items: [
                 'My Jobs 페이지에서 완료된 파일을 다시 내려받거나 필요 없는 결과를 삭제하세요.',
-                '상태 카드나 프로필에서 Cancel 버튼을 누르면 남은 청크가 중단되어 토큰을 아낄 수 있습니다.',
+                '상태 카드나 프로필에서 Cancel 버튼을 누르면 남은 청크가 중단되어 추가 JD 토큰 사용을 막을 수 있습니다.',
                 '관리자는 /admin/storage-stats로 여유 공간을 확인하고 필요 시 /admin/cleanup을 실행할 수 있습니다.'
               ]
             }
@@ -417,11 +417,11 @@
             },
             {
               q: '실행이 차단되거나 실패하면?',
-              a: 'Gemini 안전 필터가 차단되면 즉시 안내합니다. 콘텐츠를 조정하거나 최소 연관도를 낮춘 뒤 다시 시도하세요. 완료된 청크에만 토큰이 사용됩니다.'
+              a: 'Gemini 안전 필터가 차단되면 즉시 안내합니다. 콘텐츠를 조정하거나 최소 연관도를 낮춘 뒤 다시 시도하세요. 이미 처리된 청크에 대해서만 JD 토큰이 차감됩니다.'
             },
             {
               q: '진행 중인 작업을 취소할 수 있나요?',
-              a: '가능합니다. 상태 카드 또는 My Jobs 상세 화면에서 Cancel을 누르면 남은 청크는 중단되고 추가 토큰도 사용되지 않습니다.'
+              a: '가능합니다. 상태 카드 또는 My Jobs 상세 화면에서 Cancel을 누르면 남은 청크는 중단되고 추가 JD 토큰도 사용되지 않습니다.'
             }
           ]
         },

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -43,7 +43,7 @@
           </button>
           <div id="auth_area" class="nav-auth">
             <span id="user_badge" class="chip" style="display:none;"></span>
-            <span id="token_badge" class="chip" style="display:none;">Tokens: -</span>
+            <span id="token_badge" class="chip" style="display:none;">JD Tokens: -</span>
             <button id="login_btn" class="accent-button">Sign in</button>
             <div id="gsi_btn" style="display:none;"></div>
             <button id="logout_btn" class="ghost-button" style="display:none;">Logout</button>
@@ -425,7 +425,7 @@
                         <div id="testers_list" class="status-content" style="display:block;align-items:stretch;justify-content:flex-start;margin-top:.75rem;padding:.75rem;min-height:auto;"></div>
                     </div>
                       <div class="form-section">
-                          <h3 class="form-section-title">User Tokens</h3>
+                          <h3 class="form-section-title">User JD Tokens</h3>
                           <div style="display:flex;gap:.5rem;flex-wrap:wrap;align-items:center;">
                               <input type="email" id="user_search_email" placeholder="Search by email (exact)" style="min-width:260px;padding:.5rem .75rem;border:1px solid var(--border);border-radius:8px;"/>
                               <button id="search_users_btn" class="tab">Search</button>
@@ -641,9 +641,7 @@
                 const modal = document.getElementById('preflight_modal');
                 if (!modal) {
                     const chunks = pf?.total_chunks || 0;
-                    const tokens = pf?.estimated_tokens || 0;
-                    const perChunk = pf?.tokens_per_chunk || 0;
-                    const fallback = `총 청크: ${chunks}\n예상 토큰: ${tokens} (청크당 ${perChunk})\n\n이대로 분석을 시작할까요?`;
+                    const fallback = `총 청크: ${chunks}\n\n이대로 분석을 시작할까요?`;
                     resolve(window.confirm(fallback));
                     return;
                 }
@@ -664,13 +662,10 @@
                     ? `${formatNumber(jokboCount)} exam file${jokboCount === 1 ? '' : 's'}`
                     : `${formatNumber(jokboCount)} exam · ${formatNumber(lessonCount)} lecture`;
                 const chunkCount = formatNumber(pf?.total_chunks || 0);
-                const tokenCount = formatNumber(pf?.estimated_tokens || 0);
-                const perChunk = formatNumber(pf?.tokens_per_chunk || 0);
 
                 details.innerHTML = `
                     <div class="preflight-stat"><span>Files</span><span>${fileSummary}</span></div>
                     <div class="preflight-stat"><span>Chunks</span><span>${chunkCount}</span></div>
-                    <div class="preflight-stat"><span>Estimated tokens</span><span>${tokenCount} (${perChunk} / chunk)</span></div>
                 `;
 
                 title.textContent = 'Ready to start the analysis?';
@@ -1004,8 +999,6 @@
             const jbCnt = (pf && pf.files && pf.files.jokbo) ? pf.files.jokbo.length : 0;
             const lsCnt = (pf && pf.files && pf.files.lesson) ? pf.files.lesson.length : 0;
             const tc = pf.total_chunks || 0;
-            const tpc = pf.tokens_per_chunk || 0;
-            const et = pf.estimated_tokens || 0;
             const filesLine = (mode === 'exam-only')
               ? `Files: ${formatNumber(jbCnt)} exam`
               : `Files: ${formatNumber(jbCnt)} exam · ${formatNumber(lsCnt)} lecture`;
@@ -1013,7 +1006,7 @@
               <div class="mt-2 p-2 theme-surface rounded text-sm space-y-1">
                 <div>${filesLine}</div>
                 <div>Chunks: <strong>${formatNumber(tc)}</strong></div>
-                <div>Tokens: ~ <strong>${formatNumber(et)}</strong> (${formatNumber(tpc)} / chunk)</div>
+                <div class="text-xs text-gray-400">JD 토큰은 작업 완료 후 실제 사용량을 기준으로 차감됩니다.</div>
               </div>` : '';
         }
 
@@ -1219,6 +1212,16 @@
                           } catch { return ''; }
                         })();
 
+                        const tokensSummary = (() => {
+                          try {
+                            const used = data?.result?.jd_tokens_used;
+                            if (!used || used <= 0) return '';
+                            return `<div style="margin:.5rem 0; color: var(--gray-300);">JD 토큰 사용량: <strong>${formatNumber(used)}</strong></div>`;
+                          } catch {
+                            return '';
+                          }
+                        })();
+
                         statusContent.innerHTML = `
                             <div>
                                 <div class="status-message">
@@ -1226,10 +1229,13 @@
                             <small class="text-gray-500">Job ID: ${jobId}</small>
                                 </div>
                                 ${warningsHtml}
+                                ${tokensSummary}
                                 ${downloadLinks}
                             </div>
                         `;
-                        
+
+                        try { await refreshAuthUI(); } catch {}
+
                     } else if (data.status === 'FAILURE') {
                         clearInterval(interval);
                         statusBadge.className = 'status-badge error';
@@ -1241,7 +1247,7 @@
                             const pj = await pr.json();
                             const msg = (pj && pj.message) || '';
                             if (msg.includes('토큰 잔액 부족')) {
-                              extra = `<div style="margin-top:.5rem;color:#b44;">Insufficient tokens. Please contact admin for a top-up.</div>`;
+                              extra = `<div style="margin-top:.5rem;color:#b44;">Insufficient JD tokens. Please contact admin for a top-up.</div>`;
                             }
                           }
                         } catch {}
@@ -1568,10 +1574,7 @@
                 try {
                     const t = document.getElementById('token_info_line');
                     if (t && AUTH_CONFIG.tokens_enabled) {
-                        const flash = (AUTH_CONFIG.token_costs && AUTH_CONFIG.token_costs.flash) || 3;
-                        const flashLite = (AUTH_CONFIG.token_costs && AUTH_CONFIG.token_costs["flash-lite"]) || 1;
-                        const pro = (AUTH_CONFIG.token_costs && AUTH_CONFIG.token_costs.pro) || 12;
-                        t.textContent = `Token costs · Flash Latest: ${flash}/chunk · Flash Lite Latest: ${flashLite}/chunk · Pro: ${pro}/chunk`;
+                        t.textContent = 'JD 토큰은 작업 완료 후 실제 Gemini usage_metadata를 환산해 차감됩니다.';
                         t.style.display = 'block';
                     }
                 } catch {}
@@ -1635,7 +1638,7 @@
             if (CURRENT_USER) {
                 userBadge.textContent = CURRENT_USER.email || CURRENT_USER.name || 'Signed in';
                 userBadge.style.display = 'inline-block';
-                tokenBadge.textContent = `Tokens: ${CURRENT_USER.tokens ?? '-'}`;
+                tokenBadge.textContent = `JD Tokens: ${CURRENT_USER.tokens ?? '-'}`;
                 tokenBadge.style.display = 'inline-block';
                 loginBtn.style.display = 'none';
                 logoutBtn.style.display = 'inline-block';
@@ -1769,7 +1772,7 @@
                 const escUid = encodeURIComponent(uid);
                 html += `<div style="padding:.5rem 0;border-bottom:1px solid var(--border);">`+
                         `<div style=\"display:flex;gap:.5rem;flex-wrap:wrap;align-items:center;\">`+
-                        `<b>${email}</b> <span style=\"color:var(--muted)\">(${uid})</span> · <span>Tokens: ${tokens}</span>`+
+                        `<b>${email}</b> <span style=\"color:var(--muted)\">(${uid})</span> · <span>JD Tokens: ${tokens}</span>`+
                         `</div>`+
                         `<div style=\"display:flex;gap:.5rem;flex-wrap:wrap;align-items:center;margin-top:.4rem;\">`+
                         `<input type=\"number\" id=\"set_${escUid}\" placeholder=\"Set amount\" style=\"width:140px;padding:.4rem .6rem;border:1px solid var(--border);border-radius:8px;\"/>`+

--- a/pdf_processor/analyzers/base.py
+++ b/pdf_processor/analyzers/base.py
@@ -14,6 +14,7 @@ from ..api.file_manager import FileManager
 from ..pdf.operations import PDFOperations
 from ..parsers.response_parser import ResponseParser
 from ..parsers.result_merger import ResultMerger
+from ..utils.billing import BillingConverter
 from ..utils.logging import get_logger
 from ..utils.exceptions import PDFProcessorError, ContentGenerationError
 
@@ -46,6 +47,8 @@ class BaseAnalyzer(ABC):
         self.prefer_single_attempt: bool = False
         # Lazily cached StorageManager for hot cancel/progress paths
         self._sm = None
+        # Latest usage metadata from Gemini (for billing conversion)
+        self._last_usage_metadata: Optional[Any] = None
 
     def _sm_cached(self):
         """Lazily create and cache a StorageManager for this analyzer instance."""
@@ -215,7 +218,24 @@ class BaseAnalyzer(ABC):
                 pass
 
             content = [prompt] + uploaded_files
-            return self._generate_with_quality_retry(content)
+            response_text, api_usage_tokens = self._generate_with_quality_retry(content)
+            try:
+                sm = self._sm_cached()
+                if sm and api_usage_tokens > 0:
+                    usage_details = getattr(self, "_last_usage_metadata", None)
+                    model_name = getattr(self.api_client, "model_name", None)
+                    jd_tokens = BillingConverter.api_to_jd(
+                        api_total=api_usage_tokens,
+                        model=model_name,
+                        usage_details=usage_details,
+                    )
+                    if jd_tokens > 0:
+                        sm.record_token_usage(self.session_id, jd_tokens)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to record JD token usage for job {self.session_id}: {e}"
+                )
+            return response_text
         finally:
             for file in uploaded_files:
                 self.file_manager.delete_file_safe(file)
@@ -334,20 +354,20 @@ class BaseAnalyzer(ABC):
             # If anything is off, don't incorrectly treat as empty
             return False
 
-    def _generate_with_quality_retry(self, content: List[Any], retries: int = 2) -> str:
+    def _generate_with_quality_retry(
+        self, content: List[Any], retries: int = 2
+    ) -> Tuple[str, int]:
         """
         Generate content and retry if output looks suspicious per parser heuristics.
         Retries are performed with the same API key and same uploaded files.
         """
         last_error: Exception | None = None
         mode = self.get_mode()
-        # Limit attempts to a single call when Multi-API orchestrates failover,
-        # otherwise allow up to (retries+1) attempts (default 3 total) in single-key mode.
-        attempts = 1 if getattr(self, 'prefer_single_attempt', False) else max(1, retries + 1)
+        attempts = 1 if getattr(self, "prefer_single_attempt", False) else max(1, retries + 1)
         for attempt in range(1, attempts + 1):
-            # Check cancellation before each attempt
             try:
                 from ..utils.exceptions import CancelledError
+
                 sm = self._sm_cached()
                 if sm and sm.is_cancelled(self.session_id):
                     raise CancelledError("cancelled")
@@ -356,50 +376,49 @@ class BaseAnalyzer(ABC):
             except Exception:
                 pass
             try:
-                # Prefer fast-fail per key; multi-API manager will rotate keys when needed
-                response = self.api_client.generate_content(content, max_retries=1, backoff_factor=1)
+                response, api_usage_tokens = self.api_client.generate_content(
+                    content, max_retries=1, backoff_factor=1
+                )
+                try:
+                    self._last_usage_metadata = getattr(response, "usage_metadata", None)
+                except Exception:
+                    self._last_usage_metadata = None
                 text = response.text
                 try:
                     parsed = ResponseParser.parse_response(text, mode)
-                    # Treat empty results as valid (no matches) rather than fatal
                     if self._is_empty_result(parsed, mode):
                         logger.warning(
                             f"Empty {mode} result detected; treating as valid with no matches"
                         )
                         try:
-                            # Return normalized JSON to ensure downstream parser consistency
-                            return json.dumps(parsed, ensure_ascii=False)
+                            normalized = json.dumps(parsed, ensure_ascii=False)
+                            return normalized, api_usage_tokens
                         except Exception:
-                            # Fallback to raw text if serialization fails
-                            return text
+                            return text, api_usage_tokens
                     if ResponseParser.is_result_suspicious(parsed, mode):
-                        logger.warning(f"Suspicious {mode} result detected (attempt {attempt}/{attempts}); retrying...")
+                        logger.warning(
+                            f"Suspicious {mode} result detected (attempt {attempt}/{attempts}); retrying..."
+                        )
                         if attempt < attempts:
                             continue
-                        else:
-                            raise ContentGenerationError("Suspicious content after retries")
+                        raise ContentGenerationError("Suspicious content after retries")
                 except Exception as pe:
-                    # Parsing failed or suspicious; if more attempts, continue
                     last_error = pe
                     logger.warning(f"Parsing/quality check failed: {pe}")
                     if attempt < attempts:
                         continue
                     raise
-                # Looks good
-                return text
+                return text, api_usage_tokens
             except Exception as e:
+                self._last_usage_metadata = None
                 last_error = e
                 msg = str(e)
                 logger.error(f"Generation failed on attempt {attempt}/{attempts}: {msg}")
-                # Do not retry locally for prompt-block cases; give control back to
-                # the multi-API layer to potentially try a different key only when
-                # appropriate (e.g., true rate limits signaled via HTTP 429).
                 if "Prompt blocked:" in msg:
                     raise ContentGenerationError(msg)
                 if attempt < attempts:
                     continue
                 raise ContentGenerationError(msg)
-        # Should not reach here
         if last_error:
             raise last_error
         raise ContentGenerationError("Unknown generation error")

--- a/pdf_processor/api/client.py
+++ b/pdf_processor/api/client.py
@@ -16,7 +16,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 _GENAI_SPEC = importlib.util.find_spec("google.genai")
 if _GENAI_SPEC is not None:
@@ -285,7 +285,7 @@ class GeminiAPIClient:
         # NOTE: response_schema intentionally ignored for stability until validated
         response_schema: Optional[Dict[str, Any]] = None,
         max_output_tokens: Optional[int] = None,
-    ) -> Any:
+    ) -> Tuple[Any, int]:
         """
         Generate content with retry logic and error handling.
         
@@ -514,7 +514,15 @@ class GeminiAPIClient:
                             continue
                         raise ContentGenerationError("Response blocked due to safety")
                 
-                return response
+                api_usage_tokens = 0
+                try:
+                    usage = getattr(response, "usage_metadata", None)
+                    if usage is not None:
+                        api_usage_tokens = int(getattr(usage, "total_token_count", 0) or 0)
+                except Exception:
+                    api_usage_tokens = 0
+
+                return response, api_usage_tokens
                 
             except Exception as e:
                 err = str(e)

--- a/pdf_processor/utils/billing.py
+++ b/pdf_processor/utils/billing.py
@@ -1,0 +1,107 @@
+"""Utilities for converting raw Gemini API usage into JokboDude tokens."""
+
+from __future__ import annotations
+
+import math
+import os
+from functools import lru_cache
+from typing import Any, Optional
+
+
+class BillingConverter:
+    """Convert Gemini API usage metrics into JokboDude (JD) tokens.
+
+    The converter currently applies a simple multiplier that can be tuned
+    through environment variables. By default a 1:1 mapping is used, which
+    means one Gemini token maps to one JD token. Deployments can override the
+    multiplier per model family by setting one of the following environment
+    variables:
+
+    * ``JD_TOKEN_MULTIPLIER_FLASH``
+    * ``JD_TOKEN_MULTIPLIER_FLASH_LITE``
+    * ``JD_TOKEN_MULTIPLIER_PRO``
+    * ``JD_TOKEN_MULTIPLIER_DEFAULT`` (fallback for unknown models)
+
+    The multiplier represents the number of JD tokens charged per Gemini token
+    observed in ``usage_metadata.total_token_count``. The values are cached to
+    avoid recomputing on every call.
+    """
+
+    @staticmethod
+    def api_to_jd(
+        api_total: int,
+        model: Optional[str],
+        usage_details: Any = None,
+    ) -> int:
+        """Convert a Gemini token count into JD tokens.
+
+        Args:
+            api_total: The ``usage_metadata.total_token_count`` value reported
+                by Gemini. When ``None`` or non-positive the conversion yields
+                ``0``.
+            model: The model identifier used for the request. Only the primary
+                family (``flash``, ``flash-lite``, ``pro``) is inspected when
+                looking up multipliers.
+            usage_details: Optional structure with richer usage metadata. It is
+                accepted for future extensions (e.g. cache discounts) but is
+                currently unused.
+
+        Returns:
+            The converted JD token charge rounded up to the nearest integer.
+        """
+
+        if not api_total or api_total <= 0:
+            return 0
+
+        multiplier = BillingConverter._multiplier_for_model(model)
+        try:
+            converted = math.ceil(float(api_total) * multiplier)
+        except Exception:
+            converted = math.ceil(float(api_total))
+
+        return max(0, int(converted))
+
+    @staticmethod
+    def _multiplier_for_model(model: Optional[str]) -> float:
+        family = BillingConverter._canonical_model_family(model)
+        multipliers = BillingConverter._load_multipliers()
+        return multipliers.get(family, multipliers.get("default", 1.0)) or 1.0
+
+    @staticmethod
+    def _canonical_model_family(model: Optional[str]) -> str:
+        if not model:
+            return "default"
+        normalized = str(model).strip().lower()
+        if not normalized:
+            return "default"
+        if "flash-lite" in normalized or normalized.endswith("lite"):
+            return "flash-lite"
+        if "pro" in normalized:
+            return "pro"
+        if "flash" in normalized:
+            return "flash"
+        return "default"
+
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def _load_multipliers() -> dict[str, float]:
+        def _env_multiplier(name: str, default: float) -> float:
+            raw = os.getenv(name)
+            if raw is None:
+                return default
+            try:
+                value = float(raw)
+                if value <= 0:
+                    return default
+                return value
+            except Exception:
+                return default
+
+        default_multiplier = _env_multiplier("JD_TOKEN_MULTIPLIER_DEFAULT", 1.0)
+        return {
+            "default": default_multiplier,
+            "flash": _env_multiplier("JD_TOKEN_MULTIPLIER_FLASH", default_multiplier),
+            "flash-lite": _env_multiplier("JD_TOKEN_MULTIPLIER_FLASH_LITE", default_multiplier),
+            "pro": _env_multiplier("JD_TOKEN_MULTIPLIER_PRO", default_multiplier),
+        }
+

--- a/server/routes/preflight.py
+++ b/server/routes/preflight.py
@@ -1,6 +1,3 @@
-import os
-import tempfile
-import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -14,30 +11,6 @@ from .auth import require_user
 from pdf_processor.pdf.operations import PDFOperations
 
 router = APIRouter()
-
-
-def _per_chunk_tokens(model: Optional[str]) -> int:
-    """Return configured tokens-per-chunk for the given model.
-
-    Defaults: flash=3, flash-lite=1, pro=12 (overridable via env).
-    """
-    m = (model or "flash").strip().lower()
-
-    def _env_int(name: str, default: int) -> int:
-        try:
-            return max(0, int(os.getenv(name, str(default))))
-        except Exception:
-            return default
-
-    flash_cost = _env_int("FLASH_TOKENS_PER_CHUNK", 3)
-    flash_lite_cost = _env_int("FLASH_LITE_TOKENS_PER_CHUNK", 1)
-    pro_cost = _env_int("PRO_TOKENS_PER_CHUNK", 12)
-
-    if m == "pro":
-        return pro_cost
-    if m.replace("_", "-") in {"flash-lite", "flashlite"}:
-        return flash_lite_cost
-    return flash_cost
 
 
 def _build_file_info(path: Path) -> dict:
@@ -105,9 +78,6 @@ async def preflight_exam_only(
         except Exception:
             total_chunks = len(joker_info) if joker_info else 1
         total_chunks = max(1, int(total_chunks))
-        tokens_per_chunk = _per_chunk_tokens(model)
-        est_tokens = tokens_per_chunk * total_chunks
-        pct_per_chunk = 100 / total_chunks if total_chunks > 0 else 100
 
         # Augment metadata as preflight
         try:
@@ -115,8 +85,6 @@ async def preflight_exam_only(
             meta["preflight_stats"] = {
                 "jokbo": joker_info,
                 "total_chunks": total_chunks,
-                "tokens_per_chunk": tokens_per_chunk,
-                "estimated_tokens": est_tokens,
             }
             storage_manager.store_job_metadata(job_id, meta)
         except Exception:
@@ -129,9 +97,6 @@ async def preflight_exam_only(
             "multi_api": effective_multi,
             "files": {"jokbo": joker_info},
             "total_chunks": total_chunks,
-            "tokens_per_chunk": tokens_per_chunk,
-            "estimated_tokens": est_tokens,
-            "pct_per_chunk": pct_per_chunk,
         }
     except HTTPException:
         raise
@@ -196,9 +161,6 @@ async def preflight_partial_jokbo(
         if lesson_chunks_sum <= 0:
             lesson_chunks_sum = 1
         total_chunks = max(1, len(jokbo_info) * lesson_chunks_sum)
-        tokens_per_chunk = _per_chunk_tokens(model)
-        est_tokens = tokens_per_chunk * total_chunks
-        pct_per_chunk = 100 / total_chunks if total_chunks > 0 else 100
 
         try:
             meta["preflight"] = True
@@ -206,8 +168,6 @@ async def preflight_partial_jokbo(
                 "jokbo": jokbo_info,
                 "lesson": lesson_info,
                 "total_chunks": total_chunks,
-                "tokens_per_chunk": tokens_per_chunk,
-                "estimated_tokens": est_tokens,
             }
             storage_manager.store_job_metadata(job_id, meta)
         except Exception:
@@ -221,9 +181,6 @@ async def preflight_partial_jokbo(
             "min_relevance": effective_min_rel,
             "files": {"jokbo": jokbo_info, "lesson": lesson_info},
             "total_chunks": total_chunks,
-            "tokens_per_chunk": tokens_per_chunk,
-            "estimated_tokens": est_tokens,
-            "pct_per_chunk": pct_per_chunk,
         }
     except HTTPException:
         raise
@@ -286,9 +243,6 @@ async def preflight_jokbo_centric(
             except Exception:
                 lesson_chunks += 1
         total_chunks = max(1, total_jokbos * lesson_chunks)
-        pct_per_chunk = 100 / total_chunks if total_chunks > 0 else 100
-        tokens_per_chunk = _per_chunk_tokens(model)
-        est_tokens = tokens_per_chunk * total_chunks
 
         try:
             meta["preflight"] = True
@@ -296,8 +250,6 @@ async def preflight_jokbo_centric(
                 "jokbo": jokbo_info,
                 "lesson": lesson_info,
                 "total_chunks": total_chunks,
-                "tokens_per_chunk": tokens_per_chunk,
-                "estimated_tokens": est_tokens,
             }
             storage_manager.store_job_metadata(job_id, meta)
         except Exception:
@@ -311,9 +263,6 @@ async def preflight_jokbo_centric(
             "min_relevance": effective_min_rel,
             "files": {"jokbo": jokbo_info, "lesson": lesson_info},
             "total_chunks": total_chunks,
-            "tokens_per_chunk": tokens_per_chunk,
-            "estimated_tokens": est_tokens,
-            "pct_per_chunk": pct_per_chunk,
         }
     except HTTPException:
         # rethrow known HTTP errors
@@ -375,9 +324,6 @@ async def preflight_lesson_centric(
             except Exception:
                 lesson_chunks += 1
         total_chunks = max(1, lesson_chunks * max(1, total_jokbos))
-        pct_per_chunk = 100 / total_chunks if total_chunks > 0 else 100
-        tokens_per_chunk = _per_chunk_tokens(model)
-        est_tokens = tokens_per_chunk * total_chunks
 
         try:
             meta["preflight"] = True
@@ -385,8 +331,6 @@ async def preflight_lesson_centric(
                 "jokbo": jokbo_info,
                 "lesson": lesson_info,
                 "total_chunks": total_chunks,
-                "tokens_per_chunk": tokens_per_chunk,
-                "estimated_tokens": est_tokens,
             }
             storage_manager.store_job_metadata(job_id, meta)
         except Exception:
@@ -400,9 +344,6 @@ async def preflight_lesson_centric(
             "min_relevance": effective_min_rel,
             "files": {"jokbo": jokbo_info, "lesson": lesson_info},
             "total_chunks": total_chunks,
-            "tokens_per_chunk": tokens_per_chunk,
-            "estimated_tokens": est_tokens,
-            "pct_per_chunk": pct_per_chunk,
         }
     except HTTPException:
         raise

--- a/storage_manager.py
+++ b/storage_manager.py
@@ -1447,6 +1447,33 @@ class StorageManager:
             # Do not disrupt normal flow
             return
 
+    def record_token_usage(self, job_id: str, jd_tokens: int) -> None:
+        """Atomically increment the JD token usage for a job."""
+        if self.use_local_only or not self.redis_client or jd_tokens <= 0:
+            return
+        try:
+            key = f"job:{job_id}:usage"
+            self._with_retry(self.redis_client.hincrby, key, "jd_tokens_total", int(jd_tokens))
+            self._with_retry(self.redis_client.expire, key, 2592000)
+        except Exception as e:
+            logger.error(f"Failed to record JD token usage for job {job_id}: {e}")
+
+    def get_token_usage(self, job_id: str) -> int:
+        """Retrieve the total JD token usage for a job."""
+        if self.use_local_only or not self.redis_client:
+            return 0
+        try:
+            key = f"job:{job_id}:usage"
+            tokens = self._with_retry(self.redis_client.hget, key, "jd_tokens_total")
+            if tokens is None:
+                return 0
+            try:
+                return int(tokens if isinstance(tokens, (bytes, bytearray)) else tokens)
+            except Exception:
+                return int(tokens.decode() if isinstance(tokens, (bytes, bytearray)) else tokens)
+        except Exception:
+            return 0
+
     # --- Public token helpers ---
     def _token_key(self, user_id: str) -> str:
         return f"user:{user_id}:tokens"

--- a/tasks.py
+++ b/tasks.py
@@ -377,11 +377,39 @@ def run_analysis_task(job_id: str, model_type: Optional[str], multi_api: Optiona
             except Exception:
                 pass
 
+            jd_tokens_used = 0
+            user_id = None
+            try:
+                metadata = storage_manager.get_job_metadata(job_id)
+                if isinstance(metadata, dict):
+                    user_id = metadata.get("user_id")
+            except Exception:
+                metadata = None
+            try:
+                jd_tokens_used = storage_manager.get_token_usage(job_id)
+            except Exception:
+                jd_tokens_used = 0
+
+            if user_id and jd_tokens_used > 0:
+                try:
+                    if storage_manager.consume_user_tokens(user_id, jd_tokens_used):
+                        logger.info(
+                            f"Job {job_id} completed. Consumed {jd_tokens_used} JD tokens for user {user_id}."
+                        )
+                    else:
+                        logger.error(
+                            f"Job {job_id} completed but failed to consume {jd_tokens_used} JD tokens for user {user_id}."
+                        )
+                except Exception as e:
+                    logger.error(f"Failed to consume JD tokens for job {job_id}: {e}")
+
             result_payload = {
                 "status": "Complete",
                 "job_id": job_id,
                 "files_generated": len(list(output_dir.glob("*.pdf")))
             }
+            if jd_tokens_used > 0:
+                result_payload["jd_tokens_used"] = int(jd_tokens_used)
             try:
                 if aggregated_warnings["failed_files"] or aggregated_warnings["failed_chunks"]:
                     uniq = []


### PR DESCRIPTION
## Summary
- capture Gemini usage metadata and convert it to JD tokens via a new billing utility
- persist per-job JD token totals in StorageManager and deduct user balances after successful runs
- simplify preflight responses, update the frontend to remove token estimates, and surface JD token consumption after completion
- refresh the user guide to document the post-usage JD token policy

## Testing
- python -m compileall pdf_processor server storage_manager.py tasks.py

------
https://chatgpt.com/codex/tasks/task_e_68e4c454747c832b94e02bc66dde4270